### PR TITLE
`cdn_qs_*` properties on WebhookState

### DIFF
--- a/guilded/webhook/async_.py
+++ b/guilded/webhook/async_.py
@@ -318,6 +318,22 @@ class _WebhookState:
     def create_member(self, **data):
         return Member(state=self, **data)
 
+    @property
+    def cdn_qs(self) -> Optional[str]:
+        if self._parent is not None:
+            return self._parent.cdn_qs
+        return None
+
+    @property
+    def cdn_qs_expires(self) -> Optional[datetime.datetime]:
+        if self._parent is not None:
+            return self._parent.cdn_qs_expires
+        return None
+
+    @property
+    def cdn_qs_expired(self) -> bool:
+        return not self.cdn_qs_expires
+
     def __getattr__(self, attr):
         if self._parent is not None:
             return getattr(self._parent, attr)


### PR DESCRIPTION
webhook state instances still cannot sign attachments, but this fixes a bug where the library would throw an exception while attempting to parse attachments in `webhook.send()`. webhook states *could* implement the self-signing strategy i introduced in https://github.com/shayypy/guilded.py/commit/4db5680d6bc5f93e6c79e726dfd386d47533ba3a, but it seems unreasonably niche that an application would need to read its own attachments from the server